### PR TITLE
Added file to ignore unsigned packages.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure("2") do |config|
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
-  config.vm.network :forwarded_port, guest: 8080, host: 8080
+  config.vm.network :forwarded_port, guest: 8080, host: 8081
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -15,6 +15,14 @@ class must-have {
   $jira_home = "/vagrant/jira-home"
   $jira_version = "6.0"
 
+  # It's OK to install unsigned packages
+  file { "/etc/apt/apt.conf.d/99auth":
+    owner => root,
+    group => root,
+    content => "APT::Get::AllowUnauthenticated yes;",
+    mode => 644;
+  }
+
   file { "sites-available.default":
     path => "/etc/apache2/sites-available/default",
     content => template('jira/jira.sites-available.default'),


### PR DESCRIPTION
The oracle-java7-installer cannot be installed since the package
signature cannot be verified. For testing this is not a big deal
so better tell apt to ignore this error.
